### PR TITLE
Add GitHub Issue Closing and GitFlow section to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,7 @@ The organization-wide guidelines should be followed in addition to the repositor
 - [Getting Started](#getting-started)
 - [Development Workflow](#development-workflow)
 - [GitFlow Pattern](#gitflow-pattern)
+  - [GitHub Issue Closing and GitFlow](#github-issue-closing-and-gitflow)
 - [GitHub CLI Best Practices](#github-cli-best-practices)
 - [Pull Request Process](#pull-request-process)
 - [Issue Reporting Guidelines](#issue-reporting-guidelines)
@@ -99,6 +100,22 @@ Workflow:
 5. If issues are found in production, create a hotfix branch from main
 6. After fixing, merge the hotfix into both main and develop
 
+### GitHub Issue Closing and GitFlow
+
+**Important:** GitHub only automatically closes issues when PRs with keywords like "Fixes #123" or "Closes #123" are merged into the **default branch** (main). When following GitFlow, most PRs are merged into the `develop` branch, not directly to `main`.
+
+To handle this limitation, you have two options:
+
+1. **Manual closure**: After merging a PR into `develop` that implements an issue, manually close the issue with a comment explaining it's implemented in `develop` and will be in `main` with the next release.
+
+   ```bash
+   gh issue close 123 --comment "This issue has been implemented in PR #456, which has been merged into the develop branch following our GitFlow workflow."
+   ```
+
+2. **Alternative wording**: Use "Addresses #123" or "Implements #123" instead of "Fixes #123" in PR descriptions for PRs targeting `develop`. This creates a reference without promising automatic closure.
+
+This approach ensures accurate issue tracking while following GitFlow best practices.
+
 ## GitHub CLI Best Practices
 
 When using GitHub CLI (`gh`), be aware of the following limitations and best practices:
@@ -180,7 +197,9 @@ gh issue create --title "Issue Title" --body-file /tmp/issue_description.md
 
 ## Pull Request Process
 
-1. **Always reference the issue** your PR addresses using the GitHub issue number (e.g., "Fixes #123")
+1. **Always reference the issue** your PR addresses using the GitHub issue number
+   - For PRs targeting `main`: Use "Fixes #123" or "Closes #123" for automatic closure
+   - For PRs targeting `develop`: Use "Addresses #123" or "Implements #123" (see [GitHub Issue Closing and GitFlow](#github-issue-closing-and-gitflow))
 2. **Reference CONTRIBUTING.md**: Include a link to CONTRIBUTING.md in your PR description as a reminder for reviewers
 3. Follow the GitFlow pattern when targeting branches (usually target develop for features, main for hotfixes)
 4. For complex PR descriptions, use the GitHub CLI with markdown files as described in the [GitHub CLI Best Practices](#github-cli-best-practices) section


### PR DESCRIPTION
# Add GitHub Issue Closing and GitFlow section to CONTRIBUTING.md

This PR adds important information about GitHub's issue auto-closing behavior when using GitFlow.

> **Note:** This PR targets the `develop` branch following our GitFlow pattern, as documented in the updated CONTRIBUTING.md guidelines.

## Problem

GitHub only automatically closes issues when PRs with keywords like "Fixes #123" are merged into the default branch (main). When following GitFlow, most PRs are merged into the `develop` branch, not directly to `main`, which means issues referenced with "Fixes #123" don't get automatically closed.

This can lead to confusion about which issues are actually implemented, as we just experienced with issues #18, #42, and #44.

## Changes Made

- **Added a new "GitHub Issue Closing and GitFlow" section** explaining:
  - GitHub's limitation with issue auto-closing when using GitFlow
  - Options for handling this limitation (manual closure or alternative wording)
  - Examples of how to manually close issues with comments

- **Updated Pull Request Process section** with guidance on issue references:
  - For PRs targeting `main`: Use "Fixes #123" or "Closes #123" for automatic closure
  - For PRs targeting `develop`: Use "Addresses #123" or "Implements #123"

- **Updated Table of Contents** to include the new section

## Benefits

- Prevents confusion about issue status
- Provides clear guidance on how to handle issue references with GitFlow
- Ensures accurate issue tracking while following GitFlow best practices

## Related Issues

- Addresses the issue we encountered with #18, #42, and #44 remaining open after PR #51 was merged into `develop`
