### PR TITLE
Fix inconsistent menu flow for event reporting

### DIFF
--- a/fogis_reporter.py
+++ b/fogis_reporter.py
@@ -1634,6 +1634,34 @@ def _get_event_details_from_input(
                         and "Card" in event_type["name"]
                     ):
                         print(f"{event_type_id}: {event_type['name']}")
+
+                # Get card selection from user
+                event_choice_str = input("Enter card type number:")
+
+                if event_choice_str.isdigit():
+                    event_choice = int(event_choice_str)
+                    if event_choice in EVENT_TYPES and "Card" in EVENT_TYPES[event_choice]["name"]:
+                        selected_event_type = EVENT_TYPES[event_choice]
+                        event_type_id = event_choice
+                        event_type_name = selected_event_type["name"]
+                        is_goal_event = selected_event_type.get("goal", False)
+                        current_team_players_json = (
+                            team1_players_json if team_number == 1 else team2_players_json
+                        )
+                        return (
+                            team_number,
+                            selected_event_type,
+                            event_type_id,
+                            event_type_name,
+                            is_goal_event,
+                            current_team_players_json,
+                        )
+                    else:
+                        print(f"Invalid card type: {event_choice_str}")
+                        return None, None, None, None, None, None
+                else:
+                    print(f"Invalid input: {event_choice_str}")
+                    return None, None, None, None, None, None
             elif event_category == "3":  # Substitution
                 print("\nSubstitution Selected")
                 event_choice_str = "17"  # Hardcode to Substitution event type
@@ -1645,7 +1673,14 @@ def _get_event_details_from_input(
                 current_team_players_json = (
                     team1_players_json if team_number == 1 else team2_players_json
                 )
-                return None, None, None, None, None, None
+                return (
+                    team_number,
+                    selected_event_type,
+                    event_type_id,
+                    event_type_name,
+                    is_goal_event,
+                    current_team_players_json,
+                )
             if event_category == "4":  # Team Official Action
                 # Handle Team Official Action
                 event_choice_str = ""
@@ -1674,13 +1709,14 @@ def _get_event_details_from_input(
                     print("Team Official Action event type not found.")
                     return None, None, None, None, None, None
 
-            # Original behavior - show all event types
+        # If no specific category handling above, or no category specified, show all event types
+        if not event_category or event_category not in ["2", "3", "4"]:
             print("\nSelect Event Type:")
             for event_type_id, event_type in EVENT_TYPES.items():
                 if not event_type.get("control_event") and event_type_id is not None:
                     print(f"{event_type_id}: {event_type['name']}")
 
-        # For card events or when no category is specified
+        # Get event type from user
         event_choice_str = input("Enter event type number:")
 
         if event_choice_str.isdigit():


### PR DESCRIPTION
Fixes #85

## Problem
There were inconsistencies in the menu flow when reporting different types of events:

### Issue 1: Duplicate Event Type Menu for Cards
When selecting 'Card' (option 2) from the event category menu:
1. First, a 'Select Card Type' menu was shown
2. Then, a 'Select Event Type' menu was shown with ALL event types (goals, cards, substitutions)

This was confusing because the user had already chosen to report a card, but then saw all event types again.

### Issue 2: Substitution Menu Flow Broken
When selecting 'Substitution' (option 3) from the event category menu:
1. The app confirmed 'Substitution Selected'
2. But then it returned None values in the  function
3. This caused the flow to break and not proceed to the actual substitution input

## Changes
1. Fixed the substitution flow by returning the proper event details instead of None values
2. Improved the card selection flow by handling card selection directly after showing card types
3. Modified the code to only show the full event type menu when no specific category is selected

## Testing
Tested the following scenarios:
- Selecting 'Card' now shows only card types and properly handles the selection
- Selecting 'Substitution' now correctly proceeds to the substitution input
- The general event selection flow still works when no specific category is selected