### PR TITLE
Fix Python version format in UI tests workflow

### DIFF
--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -1,0 +1,32 @@
+name: UI Tests
+
+on:
+  push:
+    branches: [ main, develop ]
+  pull_request:
+    branches: [ main, develop ]
+
+jobs:
+  ui-tests:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.10
+        cache: pip
+    
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        pip install -r requirements-dev.txt
+        # Install the package in development mode
+        pip install -e .
+    
+    - name: Run UI tests
+      run: |
+        pytest tests/ui -v -m ui


### PR DESCRIPTION
This PR fixes the Python version format in the UI tests workflow file. The previous format was causing GitHub Actions to interpret '3.10' as '3.1', which is not a valid Python version for Ubuntu 24.04. This PR removes the quotes around the Python version and cache values to ensure they are interpreted correctly.